### PR TITLE
New Dockerfile using alpine-golang-make-onbuild base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM        sdurrheimer/alpine-golang-make-onbuild
+MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Copyright 2015 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION  := 0.1.0
+TARGET   := migrate
+
+include Makefile.COMMON
+
+GODEP := PATH=$(PATH):$(GOROOT)/bin GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOPATH)/bin/godep
+
+dependencies-stamp: $(GOCC) $(SRC) | $(SELFLINK)
+	if [ -d "Godeps" ]; then $(GO) get github.com/tools/godep; else $(GO) get -d; fi
+	touch $@
+
+$(BINARY): $(GOCC) $(SRC) dependencies-stamp Makefile Makefile.COMMON
+	if [ -d "Godeps" ]; then $(GODEP) go build $(GOFLAGS) -o $@; else $(GO) build $(GOFLAGS) -o $@; fi

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -1,0 +1,121 @@
+# Copyright 2015 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# THE AUTHORITATIVE VERSION OF THIS MAKEFILE LIVES IN:
+#
+#   https://github.com/prometheus/utils
+#
+# PLEASE MAKE ANY CHANGES THERE AND PROPAGATE THEM TO ALL PROMETHEUS
+# REPOSITORIES THAT ARE USING THIS MAKEFILE.
+#
+# This file provides common Makefile infrastructure for several Prometheus
+# components. This includes make tasks for downloading Go, setting up a
+# self-contained build environment, fetching Go dependencies, building
+# binaries, running tests, and doing release management. This file is intended
+# to be included from a project's Makefile, which needs to define the following
+# variables, at a minimum:
+#
+# * VERSION - The current version of the project in question.
+# * TARGET  - The desired name of the built binary.
+#
+# Many of the variables defined below are defined conditionally (using '?'),
+# which allows the project's main Makefile to override any of these settings, if
+# needed. See also:
+#
+# https://www.gnu.org/software/make/manual/html_node/Flavors.html#Flavors.
+#
+# The including Makefile may define any number of extra targets that are
+# specific to that project.
+
+VERSION ?= $(error VERSION not set in including Makefile)
+TARGET  ?= $(error TARGET not set in including Makefile)
+
+SRC    ?= $(shell find . -type f -name "*.go" ! -path "./.build/*")
+GOOS   ?= $(shell uname | tr A-Z a-z)
+GOARCH ?= $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
+
+ifeq ($(GOOS),darwin)
+	RELEASE_SUFFIX ?= -osx$(shell sw_vers -productVersion)
+endif
+
+GO_VERSION ?= 1.4.2
+GOURL      ?= https://golang.org/dl
+GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
+GOPATH     := $(CURDIR)/.build/gopath
+
+# Check for the correct version of go in the path. If we find it, use it.
+# Otherwise, prepare to build go locally.
+ifeq ($(shell command -v "go" >/dev/null && go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/'), $(GO_VERSION))
+	GOCC   ?= $(shell command -v "go")
+	GOFMT  ?= $(shell command -v "gofmt")
+	GO     ?= GOPATH=$(GOPATH) $(GOCC)
+else
+	GOROOT ?= $(CURDIR)/.build/go$(GO_VERSION)
+	GOCC   ?= $(GOROOT)/bin/go
+	GOFMT  ?= $(GOROOT)/bin/gofmt
+	GO     ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
+endif
+
+# Never honor GOBIN, should it be set at all.
+unexport GOBIN
+
+SUFFIX   ?= $(GOOS)-$(GOARCH)
+BINARY   ?= $(TARGET)
+ARCHIVE  ?= $(TARGET)-$(VERSION).$(SUFFIX).tar.gz
+ROOTPKG  ?= github.com/prometheus/$(TARGET)
+SELFLINK ?= $(GOPATH)/src/$(ROOTPKG)
+
+default: $(BINARY)
+
+$(GOCC):
+	@echo Go version $(GO_VERSION) required but not found in PATH.
+	@echo About to download and install go$(GO_VERSION) to $(GOROOT)
+	@echo Abort now if you want to manually install it system-wide instead.
+	@echo
+	@sleep 5
+	mkdir -p $(GOROOT)
+	curl -L $(GOURL)/$(GOPKG) | tar -C $(GOROOT) --strip 1 -xz
+
+$(SELFLINK):
+	mkdir -p $(dir $@)
+	ln -s $(CURDIR) $@
+
+dependencies-stamp: $(GOCC) $(SRC) | $(SELFLINK)
+	$(GO) get -d
+	touch $@
+
+$(BINARY): $(GOCC) $(SRC) dependencies-stamp Makefile Makefile.COMMON
+	$(GO) build $(GOFLAGS) -o $@
+
+.PHONY: archive
+archive: $(ARCHIVE)
+
+$(ARCHIVE): $(BINARY)
+	tar -czf $@ $<
+
+.PHONY: tag
+tag:
+	git tag $(VERSION)
+	git push --tags
+
+.PHONY: test
+test: $(GOCC) dependencies-stamp
+	$(GO) test ./...
+
+.PHONY: format
+format: $(GOCC)
+	find . -iname '*.go' | egrep -v "^\./\.build|./generated|\./Godeps|\.(l|y)\.go" | xargs -n1 $(GOFMT) -w -s=true
+
+.PHONY: clean
+clean:
+	rm -rf $(BINARY) $(ARCHIVE) .build *-stamp

--- a/README.md
+++ b/README.md
@@ -19,8 +19,21 @@ Usage:
 migrate -out=new_conf.yml old_conf.conf
 ```
 
-Migration will not preserve comments. It is generally recommended for 
+Migration will not preserve comments. It is generally recommended for
 larger files that are tedious to translate by hand.
 
-Reading the configuration documentation will provide you with further insight 
+Reading the configuration documentation will provide you with further insight
 about new possibilities.
+
+## Using Docker
+
+You can also do the migration using the [prom/migrate](https://registry.hub.docker.com/u/prom/migrate/) Docker image.
+
+For example:
+
+```bash
+docker pull prom/migrate
+
+docker run --rm -ti -v $PWD/prom_migrate:/prom_migrate \
+        prom/migrate -out=/prom_migrate/new_conf.yml /prom_migrate/old_conf.conf
+```


### PR DESCRIPTION
Following the docker related PR series.

New Dockerfile using the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild) base image whose goal is to unified the way to dockerize prometheus tools and exporters based on Golang.

The binary is build using make. (Golang is installed via make too, respecting the GO_VERSION).

A testable image is available under my name on Docker hub : [Link](https://registry.hub.docker.com/u/sdurrheimer/alertmanager/)

I have also added some Docker usage instructions in the readme.

As always, the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild)  image can be also move under Prometheus organization.

@fabxc @discordianfish 
